### PR TITLE
Bugfix/secondarrayelementvalidation

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -22,6 +22,8 @@
                 "${workspaceFolder}/build/src/**/*.js"
             ],
             "outputCapture": "std",
+            "port": 9229,
+            "internalConsoleOptions": "openOnSessionStart",
             "cwd": "${workspaceFolder}/build/src",
             "preLaunchTask": "Build Debug",
         },
@@ -35,12 +37,17 @@
             "program": "${workspaceFolder}\\build\\src\\index.js",
             "args": [
                 "gps",
-                "-v [NamespaceIndex, NodeId, ExpandedNodeId]"
+                "-v",
+                "NamespaceIndex",
+                "NodeId",
+                "ExpandedNodeId"
             ],
             "outFiles": [
                 "${workspaceFolder}/build/src/**/*.js"
             ],
             "outputCapture": "std",
+            "port": 9229,
+            "internalConsoleOptions": "openOnSessionStart",
             "cwd": "${workspaceFolder}/build/src",
             "preLaunchTask": "Build Debug",
         },
@@ -57,6 +64,8 @@
                 "${workspaceFolder}/build/src/**/*.js"
             ],
             "outputCapture": "std",
+            "port": 9229,
+            "internalConsoleOptions": "openOnSessionStart",
             "cwd": "${workspaceFolder}/build/src",
             "preLaunchTask": "Build Debug",
         },

--- a/output/publishednodes-schema.json
+++ b/output/publishednodes-schema.json
@@ -1,10 +1,12 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$comment": "The outer most object of the configuration file must be an array, though it's contents may adhear to several differing schema, presented from newest to oldest supported schema.",
 	"type": "array",
 	"items": {
-		"type": "object",
+		"$comment": "The nested 'oneOf' under 'items' ensures that each array element must comform to one of the three following subschema. See the following stackoverflow post for details: https://stackoverflow.com/a/67314134/1276028",
 		"oneOf": [
 			{
+				"$comment": "The following subschema is the most current allowable configuration schema for OPC Publisher",
 				"type": "object",
 				"properties": {
 					"DataSetWriterId": {
@@ -28,6 +30,7 @@
 					"EndpointUrl": {
 						"type": "string",
 						"format": "uri",
+						"$comment": "Endpoint urls must adhear to OPC UA server addressing schemes which begin with `opc.tcp` followed by acceptable URI formatting, e.g. `opc.tcp?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\\(\\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+`",
 						"pattern": "opc.tcp?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\\(\\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+"
 					},
 					"UseSecurity": {
@@ -35,41 +38,39 @@
 					},
 					"OpcNodes": {
 						"type": "array",
-						"items": [
-							{
-								"type": "object",
-								"properties": {
-									"Id": {
-										"type": "string",
-										"pattern": "(^nsu=http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*(),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+/;(i=(\\d+)$))|(^nsu=http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*(),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+/;(s=([\\x00-\\x7F]|([\\xC2-\\xDF]|\\xE0[\\xA0-\\xBF]|\\xED[\\x80-\\x9F]|(|[\\xE1-\\xEC]|[\\xEE-\\xEF]|\\xF0[\\x90-\\xBF]|\\xF4[\\x80-\\x8F]|[\\xF1-\\xF3][\\x80-\\xBF])[\\x80-\\xBF])[\\x80-\\xBF])+$))|(^nsu=http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*(),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+/;(g=([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$))|(^nsu=http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*(),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+/;(b=(?:[A-Za-z\\d+/]{4})*(?:[A-Za-z\\d+/]{3}=|[A-Za-z\\d+/]{2}==)$))|(^ns=(\\d+);(i=(\\d+)$))|(^ns=(\\d+);(s=([\\x00-\\x7F]|([\\xC2-\\xDF]|\\xE0[\\xA0-\\xBF]|\\xED[\\x80-\\x9F]|(|[\\xE1-\\xEC]|[\\xEE-\\xEF]|\\xF0[\\x90-\\xBF]|\\xF4[\\x80-\\x8F]|[\\xF1-\\xF3][\\x80-\\xBF])[\\x80-\\xBF])[\\x80-\\xBF])+$))|(^ns=(\\d+);(g=([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$))|(^ns=(\\d+);(b=(?:[A-Za-z\\d+/]{4})*(?:[A-Za-z\\d+/]{3}=|[A-Za-z\\d+/]{2}==)$))|(^i=(\\d+)$)|(^s=([\\x00-\\x7F]|([\\xC2-\\xDF]|\\xE0[\\xA0-\\xBF]|\\xED[\\x80-\\x9F]|(|[\\xE1-\\xEC]|[\\xEE-\\xEF]|\\xF0[\\x90-\\xBF]|\\xF4[\\x80-\\x8F]|[\\xF1-\\xF3][\\x80-\\xBF])[\\x80-\\xBF])[\\x80-\\xBF])+$)|(^g=([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$)|(^b=(?:[A-Za-z\\d+/]{4})*(?:[A-Za-z\\d+/]{3}=|[A-Za-z\\d+/]{2}==)$)"
-									},
-									"DisplayName": {
-										"type": "string"
-									},
-									"DataSetFieldId": {
-										"type": "string"
-									},
-									"OpcSamplingInterval": {
-										"type": "integer"
-									},
-									"OpcPublishingInterval": {
-										"type": "integer"
-									},
-									"HeartbeatInterval": {
-										"type": "integer"
-									},
-									"HeartbeatIntervalTimespan": {
-										"type": "string"
-									},
-									"SkipFirst": {
-										"type": "boolean"
-									}
+						"items": {
+							"type": "object",
+							"properties": {
+								"Id": {
+									"type": "string",
+									"pattern": "(^nsu=http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*(),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+/;(i=(\\d+)$))|(^nsu=http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*(),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+/;(s=([\\x00-\\x7F]|([\\xC2-\\xDF]|\\xE0[\\xA0-\\xBF]|\\xED[\\x80-\\x9F]|(|[\\xE1-\\xEC]|[\\xEE-\\xEF]|\\xF0[\\x90-\\xBF]|\\xF4[\\x80-\\x8F]|[\\xF1-\\xF3][\\x80-\\xBF])[\\x80-\\xBF])[\\x80-\\xBF])+$))|(^nsu=http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*(),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+/;(g=([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$))|(^nsu=http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*(),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+/;(b=(?:[A-Za-z\\d+/]{4})*(?:[A-Za-z\\d+/]{3}=|[A-Za-z\\d+/]{2}==)$))|(^ns=(\\d+);(i=(\\d+)$))|(^ns=(\\d+);(s=([\\x00-\\x7F]|([\\xC2-\\xDF]|\\xE0[\\xA0-\\xBF]|\\xED[\\x80-\\x9F]|(|[\\xE1-\\xEC]|[\\xEE-\\xEF]|\\xF0[\\x90-\\xBF]|\\xF4[\\x80-\\x8F]|[\\xF1-\\xF3][\\x80-\\xBF])[\\x80-\\xBF])[\\x80-\\xBF])+$))|(^ns=(\\d+);(g=([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$))|(^ns=(\\d+);(b=(?:[A-Za-z\\d+/]{4})*(?:[A-Za-z\\d+/]{3}=|[A-Za-z\\d+/]{2}==)$))|(^i=(\\d+)$)|(^s=([\\x00-\\x7F]|([\\xC2-\\xDF]|\\xE0[\\xA0-\\xBF]|\\xED[\\x80-\\x9F]|(|[\\xE1-\\xEC]|[\\xEE-\\xEF]|\\xF0[\\x90-\\xBF]|\\xF4[\\x80-\\x8F]|[\\xF1-\\xF3][\\x80-\\xBF])[\\x80-\\xBF])[\\x80-\\xBF])+$)|(^g=([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$)|(^b=(?:[A-Za-z\\d+/]{4})*(?:[A-Za-z\\d+/]{3}=|[A-Za-z\\d+/]{2}==)$)"
 								},
-								"required": [
-									"Id"
-								]
-							}
-						]
+								"DisplayName": {
+									"type": "string"
+								},
+								"DataSetFieldId": {
+									"type": "string"
+								},
+								"OpcSamplingInterval": {
+									"type": "integer"
+								},
+								"OpcPublishingInterval": {
+									"type": "integer"
+								},
+								"HeartbeatInterval": {
+									"type": "integer"
+								},
+								"HeartbeatIntervalTimespan": {
+									"type": "string"
+								},
+								"SkipFirst": {
+									"type": "boolean"
+								}
+							},
+							"required": [
+								"Id"
+							]
+						}
 					}
 				},
 				"required": [
@@ -98,6 +99,7 @@
 					"EndpointUrl": {
 						"type": "string",
 						"format": "uri",
+						"$comment": "Endpoint urls must adhear to OPC UA server addressing schemes which begin with `opc.tcp` followed by acceptable URI formatting, e.g. `opc.tcp?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\\(\\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+`",
 						"pattern": "opc.tcp?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\\(\\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+"
 					},
 					"UseSecurity": {
@@ -105,26 +107,25 @@
 					},
 					"OpcNodes": {
 						"type": "array",
-						"items": [
-							{
-								"type": "object",
-								"properties": {
-									"ExpandedNodeId": {
-										"type": "string",
-										"pattern": "(^nsu=http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*(),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+/;(i=(\\d+)$))|(^nsu=http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*(),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+/;(s=([\\x00-\\x7F]|([\\xC2-\\xDF]|\\xE0[\\xA0-\\xBF]|\\xED[\\x80-\\x9F]|(|[\\xE1-\\xEC]|[\\xEE-\\xEF]|\\xF0[\\x90-\\xBF]|\\xF4[\\x80-\\x8F]|[\\xF1-\\xF3][\\x80-\\xBF])[\\x80-\\xBF])[\\x80-\\xBF])+$))|(^nsu=http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*(),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+/;(g=([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$))|(^nsu=http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*(),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+/;(b=(?:[A-Za-z\\d+/]{4})*(?:[A-Za-z\\d+/]{3}=|[A-Za-z\\d+/]{2}==)$))"
-									},
-									"OpcSamplingInterval": {
-										"type": "integer"
-									},
-									"OpcPublishingInterval": {
-										"type": "integer"
-									}
+						"items": {
+							"type": "object",
+							"properties": {
+								"ExpandedNodeId": {
+									"type": "string",
+									"$comment": "this subschema only supports the use of the expanded nodeid format",
+									"pattern": "(^nsu=http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*(),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+/;(i=(\\d+)$))|(^nsu=http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*(),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+/;(s=([\\x00-\\x7F]|([\\xC2-\\xDF]|\\xE0[\\xA0-\\xBF]|\\xED[\\x80-\\x9F]|(|[\\xE1-\\xEC]|[\\xEE-\\xEF]|\\xF0[\\x90-\\xBF]|\\xF4[\\x80-\\x8F]|[\\xF1-\\xF3][\\x80-\\xBF])[\\x80-\\xBF])[\\x80-\\xBF])+$))|(^nsu=http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*(),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+/;(g=([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$))|(^nsu=http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*(),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+/;(b=(?:[A-Za-z\\d+/]{4})*(?:[A-Za-z\\d+/]{3}=|[A-Za-z\\d+/]{2}==)$))"
 								},
-								"required": [
-									"ExpandedNodeId"
-								]
-							}
-						]
+								"OpcSamplingInterval": {
+									"type": "integer"
+								},
+								"OpcPublishingInterval": {
+									"type": "integer"
+								}
+							},
+							"required": [
+								"ExpandedNodeId"
+							]
+						}
 					}
 				},
 				"required": [
@@ -153,6 +154,7 @@
 					"EndpointUrl": {
 						"type": "string",
 						"format": "uri",
+						"$comment": "Endpoint urls must adhear to OPC UA server addressing schemes which begin with `opc.tcp` followed by acceptable URI formatting, e.g. `opc.tcp?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\\(\\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+`",
 						"pattern": "opc.tcp?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\\(\\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+"
 					},
 					"NodeId": {
@@ -160,6 +162,7 @@
 						"properties": {
 							"Identifier": {
 								"type": "string",
+								"$comment": "The only supported, historical ID format for this subschema is 'NodeId', e.g. 'NodeId' : 'i=12345' ",
 								"pattern": "(^i=(\\d+)$)|(^s=([\\x00-\\x7F]|([\\xC2-\\xDF]|\\xE0[\\xA0-\\xBF]|\\xED[\\x80-\\x9F]|(|[\\xE1-\\xEC]|[\\xEE-\\xEF]|\\xF0[\\x90-\\xBF]|\\xF4[\\x80-\\x8F]|[\\xF1-\\xF3][\\x80-\\xBF])[\\x80-\\xBF])[\\x80-\\xBF])+$)|(^g=([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$)|(^b=(?:[A-Za-z\\d+/]{4})*(?:[A-Za-z\\d+/]{3}=|[A-Za-z\\d+/]{2}==)$)|(^ns=(\\d+);(i=(\\d+)$))|(^ns=(\\d+);(s=([\\x00-\\x7F]|([\\xC2-\\xDF]|\\xE0[\\xA0-\\xBF]|\\xED[\\x80-\\x9F]|(|[\\xE1-\\xEC]|[\\xEE-\\xEF]|\\xF0[\\x90-\\xBF]|\\xF4[\\x80-\\x8F]|[\\xF1-\\xF3][\\x80-\\xBF])[\\x80-\\xBF])[\\x80-\\xBF])+$))|(^ns=(\\d+);(g=([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$))|(^ns=(\\d+);(b=(?:[A-Za-z\\d+/]{4})*(?:[A-Za-z\\d+/]{3}=|[A-Za-z\\d+/]{2}==)$))"
 							},
 							"OpcSamplingInterval": {

--- a/src/publishednodes.ts
+++ b/src/publishednodes.ts
@@ -186,169 +186,202 @@ export function getPublishedNodesSchema(
       type: 'object',
       oneOf: [
         {
-          type: 'object',
-          properties: {
-            DataSetWriterId: {
-              type: 'string',
-            },
-            DataSetWriterGroup: {
-              type: 'string',
-            },
-            DataSetPublishingInterval: {
-              type: ['integer', 'string'],
-            },
-            EncryptedAuthPassword: {
-              type: 'string',
-            },
-            OpcAuthenticationPassword: {
-              type: 'string',
-            },
-            EndpointUrl: {
-              type: 'string',
-              format: 'uri',
-              pattern: `${endpointRegexStr}`,
-            },
-            UseSecurity: {
-              type: 'boolean',
-            },
-            OpcNodes: {
-              type: 'array',
-              items: [
-                {
-                  type: 'object',
-                  properties: {
-                    Id: {
-                      type: 'string',
-                      pattern: `${generatePublishedNodesNodeIdRegex(formats)}`,
-                    },
-                    DisplayName: {
-                      type: 'string',
-                    },
-                    DataSetFieldId: {
-                      type: 'string',
-                    },
-                    OpcSamplingInterval: {
-                      type: 'integer',
-                    },
-                    OpcPublishingInterval: {
-                      type: 'integer',
-                    },
-                    HeartbeatInterval: {
-                      type: 'integer',
-                    },
-                    HeartbeatIntervalTimespan: {
-                      type: 'string',
-                    },
-                    SkipFirst: {
-                      type: 'boolean',
-                    },
-                  },
-                  required: ['Id'],
+          if: {
+            properties: {
+              OpcNodes: {
+                properties: {
+                  Id: true
                 },
-              ],
+              }
             },
           },
-          required: ['EndpointUrl', 'OpcNodes'],
-        },
-        {
-          type: 'object',
-          properties: {
-            DataSetWriterId: {
-              type: 'string',
-            },
-            DataSetWriterGroup: {
-              type: 'string',
-            },
-            DataSetPublishingInterval: {
-              type: 'string',
-            },
-            EncryptedAuthPassword: {
-              type: 'string',
-            },
-            OpcAuthenticationPassword: {
-              type: 'string',
-            },
-            EndpointUrl: {
-              type: 'string',
-              format: 'uri',
-              pattern: `${endpointRegexStr}`,
-            },
-            UseSecurity: {
-              type: 'boolean',
-            },
-            OpcNodes: {
-              type: 'array',
-              items: [
-                {
-                  type: 'object',
-                  properties: {
-                    ExpandedNodeId: {
-                      type: 'string',
-                      // this should only use the expanded nodeid format
-                      pattern: `${generatePublishedNodesNodeIdRegex([
-                        NodeIdFormat.ExpandedNodeId.toString(),
-                      ])}`,
-                    },
-                    OpcSamplingInterval: {
-                      type: 'integer',
-                    },
-                    OpcPublishingInterval: {
-                      type: 'integer',
-                    },
-                  },
-                  required: ['ExpandedNodeId'],
-                },
-              ],
-            },
-          },
-          required: ['EndpointUrl', 'OpcNodes'],
-        },
-        {
-          type: 'object',
-          properties: {
-            DataSetWriterId: {
-              type: 'string',
-            },
-            DataSetWriterGroup: {
-              type: 'string',
-            },
-            DataSetPublishingInterval: {
-              type: 'string',
-            },
-            EncryptedAuthPassword: {
-              type: 'string',
-            },
-            OpcAuthenticationPassword: {
-              type: 'string',
-            },
-            EndpointUrl: {
-              type: 'string',
-              format: 'uri',
-              pattern: `${endpointRegexStr}`,
-            },
-            NodeId: {
-              type: 'object',
-              properties: {
-                Identifier: {
-                  type: 'string',
-                  // the only supported historical format for this schema
-                  // is the NodeId format; e.g. "NodeId" : "i=12345"
-                  pattern: `${generatePublishedNodesNodeIdRegex([
-                    NodeIdFormat.NodeId.toString(),
-                    NodeIdFormat.NamespaceIndex.toString(),
-                  ])}`,
-                },
-                OpcSamplingInterval: {
-                  type: 'integer',
-                },
-                OpcPublishingInterval: {
-                  type: 'integer',
-                },
+          then: {
+            type: 'object',
+            properties: {
+              DataSetWriterId: {
+                type: 'string',
               },
-              required: ['Identifier'],
+              DataSetWriterGroup: {
+                type: 'string',
+              },
+              DataSetPublishingInterval: {
+                type: ['integer', 'string'],
+              },
+              EncryptedAuthPassword: {
+                type: 'string',
+              },
+              OpcAuthenticationPassword: {
+                type: 'string',
+              },
+              EndpointUrl: {
+                type: 'string',
+                format: 'uri',
+                pattern: `${endpointRegexStr}`,
+              },
+              UseSecurity: {
+                type: 'boolean',
+              },
+              OpcNodes: {
+                type: 'array',
+                items: [
+                  {
+                    type: 'object',
+                    properties: {
+                      Id: {
+                        type: 'string',
+                        pattern: `${generatePublishedNodesNodeIdRegex(formats)}`,
+                      },
+                      DisplayName: {
+                        type: 'string',
+                      },
+                      DataSetFieldId: {
+                        type: 'string',
+                      },
+                      OpcSamplingInterval: {
+                        type: 'integer',
+                      },
+                      OpcPublishingInterval: {
+                        type: 'integer',
+                      },
+                      HeartbeatInterval: {
+                        type: 'integer',
+                      },
+                      HeartbeatIntervalTimespan: {
+                        type: 'string',
+                      },
+                      SkipFirst: {
+                        type: 'boolean',
+                      },
+                    },
+                    required: ['Id'],
+                  },
+                ],
+              },
             },
+            required: ['EndpointUrl', 'OpcNodes'],
           },
-          required: ['EndpointUrl', 'NodeId'],
+        },
+        {
+          if: {
+            properties: {
+              OpcNodes: {
+                properties: {
+                  ExpandedNodeId: true
+                }
+              }
+            }
+          },
+          then: {
+            type: 'object',
+            properties: {
+              DataSetWriterId: {
+                type: 'string',
+              },
+              DataSetWriterGroup: {
+                type: 'string',
+              },
+              DataSetPublishingInterval: {
+                type: 'string',
+              },
+              EncryptedAuthPassword: {
+                type: 'string',
+              },
+              OpcAuthenticationPassword: {
+                type: 'string',
+              },
+              EndpointUrl: {
+                type: 'string',
+                format: 'uri',
+                pattern: `${endpointRegexStr}`,
+              },
+              UseSecurity: {
+                type: 'boolean',
+              },
+              OpcNodes: {
+                type: 'array',
+                items: [
+                  {
+                    type: 'object',
+                    properties: {
+                      ExpandedNodeId: {
+                        type: 'string',
+                        // this should only use the expanded nodeid format
+                        pattern: `${generatePublishedNodesNodeIdRegex([
+                          NodeIdFormat.ExpandedNodeId.toString(),
+                        ])}`,
+                      },
+                      OpcSamplingInterval: {
+                        type: 'integer',
+                      },
+                      OpcPublishingInterval: {
+                        type: 'integer',
+                      },
+                    },
+                    required: ['ExpandedNodeId'],
+                  },
+                ],
+              },
+            },
+            required: ['EndpointUrl', 'OpcNodes'],
+          },
+        },
+        {
+          if: {
+            properties: {
+              NodeId: {
+                properties: {
+                  Identifier: true
+                }
+              },
+            }
+          },
+          then: {
+            type: 'object',
+            properties: {
+              DataSetWriterId: {
+                type: 'string',
+              },
+              DataSetWriterGroup: {
+                type: 'string',
+              },
+              DataSetPublishingInterval: {
+                type: 'string',
+              },
+              EncryptedAuthPassword: {
+                type: 'string',
+              },
+              OpcAuthenticationPassword: {
+                type: 'string',
+              },
+              EndpointUrl: {
+                type: 'string',
+                format: 'uri',
+                pattern: `${endpointRegexStr}`,
+              },
+              NodeId: {
+                type: 'object',
+                properties: {
+                  Identifier: {
+                    type: 'string',
+                    // the only supported historical format for this schema
+                    // is the NodeId format; e.g. "NodeId" : "i=12345"
+                    pattern: `${generatePublishedNodesNodeIdRegex([
+                      NodeIdFormat.NodeId.toString(),
+                      NodeIdFormat.NamespaceIndex.toString(),
+                    ])}`,
+                  },
+                  OpcSamplingInterval: {
+                    type: 'integer',
+                  },
+                  OpcPublishingInterval: {
+                    type: 'integer',
+                  },
+                },
+                required: ['Identifier'],
+              },
+            },
+            required: ['EndpointUrl', 'NodeId'],
+          },
         },
       ],
     },
@@ -364,15 +397,15 @@ export function getPublishedNodesSchema(
     const s = schema;
     const updatedOneOfSchema = s.items.oneOf.map(element => {
       // grab the schema elements that allow UseSecurity
-      if (element.properties.UseSecurity) {
+      if (element.then.properties.UseSecurity) {
         // ensure that UseSecurity is a required field
-        element.required.push('UseSecurity');
+        element.then.required.push('UseSecurity');
         // set a const to ensure the value is set to true
         // when useSecurity is true
         if (useSecurity) {
-          const useSecurity = element.properties.UseSecurity;
+          const useSecurity = element.then.properties.UseSecurity;
           const useSecurityConst = {...useSecurity, const: true};
-          element.properties.UseSecurity = useSecurityConst;
+          element.then.properties.UseSecurity = useSecurityConst;
         }
       }
       return element;

--- a/src/publishednodes.ts
+++ b/src/publishednodes.ts
@@ -181,193 +181,121 @@ export function getPublishedNodesSchema(
   const schema = {
     //$id: jsonSchemaUrl,
     $schema: jsonSchemaUrl,
+    $comment: "The outer most object of the configuration file must be an array, though " +
+      "it's contents may adhear to several differing schema, presented from newest to oldest supported schema.",
     type: 'array',
     items: {
-      type: 'object',
+      $comment: "The nested 'oneOf' under 'items' ensures that each array element must comform " +
+        "to one of the three following subschema. See the following stackoverflow post for details: " +
+        "https://stackoverflow.com/a/67314134/1276028",
       oneOf: [
         {
-          if: {
-            properties: {
-              OpcNodes: {
-                properties: {
-                  Id: true
-                },
-              }
+          $comment: "The following subschema is the most current allowable configuration schema for OPC Publisher",
+          type: 'object',
+          properties: {
+            DataSetWriterId: {
+              type: 'string',
             },
-          },
-          then: {
-            type: 'object',
-            properties: {
-              DataSetWriterId: {
-                type: 'string',
-              },
-              DataSetWriterGroup: {
-                type: 'string',
-              },
-              DataSetPublishingInterval: {
-                type: ['integer', 'string'],
-              },
-              EncryptedAuthPassword: {
-                type: 'string',
-              },
-              OpcAuthenticationPassword: {
-                type: 'string',
-              },
-              EndpointUrl: {
-                type: 'string',
-                format: 'uri',
-                pattern: `${endpointRegexStr}`,
-              },
-              UseSecurity: {
-                type: 'boolean',
-              },
-              OpcNodes: {
-                type: 'array',
-                items: [
-                  {
-                    type: 'object',
-                    properties: {
-                      Id: {
-                        type: 'string',
-                        pattern: `${generatePublishedNodesNodeIdRegex(formats)}`,
-                      },
-                      DisplayName: {
-                        type: 'string',
-                      },
-                      DataSetFieldId: {
-                        type: 'string',
-                      },
-                      OpcSamplingInterval: {
-                        type: 'integer',
-                      },
-                      OpcPublishingInterval: {
-                        type: 'integer',
-                      },
-                      HeartbeatInterval: {
-                        type: 'integer',
-                      },
-                      HeartbeatIntervalTimespan: {
-                        type: 'string',
-                      },
-                      SkipFirst: {
-                        type: 'boolean',
-                      },
-                    },
-                    required: ['Id'],
-                  },
-                ],
-              },
+            DataSetWriterGroup: {
+              type: 'string',
             },
-            required: ['EndpointUrl', 'OpcNodes'],
-          },
-        },
-        {
-          if: {
-            properties: {
-              OpcNodes: {
-                properties: {
-                  ExpandedNodeId: true
-                }
-              }
-            }
-          },
-          then: {
-            type: 'object',
-            properties: {
-              DataSetWriterId: {
-                type: 'string',
-              },
-              DataSetWriterGroup: {
-                type: 'string',
-              },
-              DataSetPublishingInterval: {
-                type: 'string',
-              },
-              EncryptedAuthPassword: {
-                type: 'string',
-              },
-              OpcAuthenticationPassword: {
-                type: 'string',
-              },
-              EndpointUrl: {
-                type: 'string',
-                format: 'uri',
-                pattern: `${endpointRegexStr}`,
-              },
-              UseSecurity: {
-                type: 'boolean',
-              },
-              OpcNodes: {
-                type: 'array',
-                items: [
-                  {
-                    type: 'object',
-                    properties: {
-                      ExpandedNodeId: {
-                        type: 'string',
-                        // this should only use the expanded nodeid format
-                        pattern: `${generatePublishedNodesNodeIdRegex([
-                          NodeIdFormat.ExpandedNodeId.toString(),
-                        ])}`,
-                      },
-                      OpcSamplingInterval: {
-                        type: 'integer',
-                      },
-                      OpcPublishingInterval: {
-                        type: 'integer',
-                      },
-                    },
-                    required: ['ExpandedNodeId'],
-                  },
-                ],
-              },
+            DataSetPublishingInterval: {
+              type: ['integer', 'string'],
             },
-            required: ['EndpointUrl', 'OpcNodes'],
-          },
-        },
-        {
-          if: {
-            properties: {
-              NodeId: {
-                properties: {
-                  Identifier: true
-                }
-              },
-            }
-          },
-          then: {
-            type: 'object',
-            properties: {
-              DataSetWriterId: {
-                type: 'string',
-              },
-              DataSetWriterGroup: {
-                type: 'string',
-              },
-              DataSetPublishingInterval: {
-                type: 'string',
-              },
-              EncryptedAuthPassword: {
-                type: 'string',
-              },
-              OpcAuthenticationPassword: {
-                type: 'string',
-              },
-              EndpointUrl: {
-                type: 'string',
-                format: 'uri',
-                pattern: `${endpointRegexStr}`,
-              },
-              NodeId: {
+            EncryptedAuthPassword: {
+              type: 'string',
+            },
+            OpcAuthenticationPassword: {
+              type: 'string',
+            },
+            EndpointUrl: {
+              type: 'string',
+              format: 'uri',
+              $comment: "Endpoint urls must adhear to OPC UA server addressing schemes which begin with `opc.tcp` followed by " +
+                "acceptable URI formatting, e.g. `opc.tcp?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\\(\\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+`",
+              pattern: `${endpointRegexStr}`,
+            },
+            UseSecurity: {
+              type: 'boolean',
+            },
+            OpcNodes: {
+              type: 'array',
+              items:
+              {
                 type: 'object',
                 properties: {
-                  Identifier: {
+                  Id: {
                     type: 'string',
-                    // the only supported historical format for this schema
-                    // is the NodeId format; e.g. "NodeId" : "i=12345"
+                    pattern: `${generatePublishedNodesNodeIdRegex(formats)}`,
+                  },
+                  DisplayName: {
+                    type: 'string',
+                  },
+                  DataSetFieldId: {
+                    type: 'string',
+                  },
+                  OpcSamplingInterval: {
+                    type: 'integer',
+                  },
+                  OpcPublishingInterval: {
+                    type: 'integer',
+                  },
+                  HeartbeatInterval: {
+                    type: 'integer',
+                  },
+                  HeartbeatIntervalTimespan: {
+                    type: 'string',
+                  },
+                  SkipFirst: {
+                    type: 'boolean',
+                  },
+                },
+                required: ['Id'],
+              },
+
+            },
+          },
+          required: ['EndpointUrl', 'OpcNodes'],
+        },
+        {
+          type: 'object',
+          properties: {
+            DataSetWriterId: {
+              type: 'string',
+            },
+            DataSetWriterGroup: {
+              type: 'string',
+            },
+            DataSetPublishingInterval: {
+              type: 'string',
+            },
+            EncryptedAuthPassword: {
+              type: 'string',
+            },
+            OpcAuthenticationPassword: {
+              type: 'string',
+            },
+            EndpointUrl: {
+              type: 'string',
+              format: 'uri',
+              $comment: "Endpoint urls must adhear to OPC UA server addressing schemes which begin with `opc.tcp` followed by " +
+                "acceptable URI formatting, e.g. `opc.tcp?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\\(\\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+`",
+              pattern: `${endpointRegexStr}`,
+            },
+            UseSecurity: {
+              type: 'boolean',
+            },
+            OpcNodes: {
+              type: 'array',
+              items:
+              {
+                type: 'object',
+                properties: {
+                  ExpandedNodeId: {
+                    type: 'string',
+                    $comment: "this subschema only supports the use of the expanded nodeid format",
                     pattern: `${generatePublishedNodesNodeIdRegex([
-                      NodeIdFormat.NodeId.toString(),
-                      NodeIdFormat.NamespaceIndex.toString(),
+                      NodeIdFormat.ExpandedNodeId.toString(),
                     ])}`,
                   },
                   OpcSamplingInterval: {
@@ -377,14 +305,62 @@ export function getPublishedNodesSchema(
                     type: 'integer',
                   },
                 },
-                required: ['Identifier'],
+                required: ['ExpandedNodeId'],
               },
             },
-            required: ['EndpointUrl', 'NodeId'],
           },
+          required: ['EndpointUrl', 'OpcNodes'],
         },
-      ],
-    },
+        {
+          type: 'object',
+          properties: {
+            DataSetWriterId: {
+              type: 'string',
+            },
+            DataSetWriterGroup: {
+              type: 'string',
+            },
+            DataSetPublishingInterval: {
+              type: 'string',
+            },
+            EncryptedAuthPassword: {
+              type: 'string',
+            },
+            OpcAuthenticationPassword: {
+              type: 'string',
+            },
+            EndpointUrl: {
+              type: 'string',
+              format: 'uri',
+              $comment: "Endpoint urls must adhear to OPC UA server addressing schemes which begin with `opc.tcp` followed by " +
+                "acceptable URI formatting, e.g. `opc.tcp?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\\(\\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+`",
+              pattern: `${endpointRegexStr}`,
+            },
+            NodeId: {
+              type: 'object',
+              properties: {
+                Identifier: {
+                  type: 'string',
+                  $comment: "The only supported, historical ID format for this subschema is 'NodeId', e.g. 'NodeId' : 'i=12345' ",
+                  pattern: `${generatePublishedNodesNodeIdRegex([
+                    NodeIdFormat.NodeId.toString(),
+                    NodeIdFormat.NamespaceIndex.toString(),
+                  ])}`,
+                },
+                OpcSamplingInterval: {
+                  type: 'integer',
+                },
+                OpcPublishingInterval: {
+                  type: 'integer',
+                },
+              },
+              required: ['Identifier'],
+            },
+          },
+          required: ['EndpointUrl', 'NodeId'],
+        }
+      ]
+    }
   };
 
   // if the requireUseSecurity flag is set via the command
@@ -397,15 +373,15 @@ export function getPublishedNodesSchema(
     const s = schema;
     const updatedOneOfSchema = s.items.oneOf.map(element => {
       // grab the schema elements that allow UseSecurity
-      if (element.then.properties.UseSecurity) {
+      if (element.properties.UseSecurity) {
         // ensure that UseSecurity is a required field
-        element.then.required.push('UseSecurity');
+        element.required.push('UseSecurity');
         // set a const to ensure the value is set to true
         // when useSecurity is true
         if (useSecurity) {
-          const useSecurity = element.then.properties.UseSecurity;
+          const useSecurity = element.properties.UseSecurity;
           const useSecurityConst = {...useSecurity, const: true};
-          element.then.properties.UseSecurity = useSecurityConst;
+          element.properties.UseSecurity = useSecurityConst;
         }
       }
       return element;
@@ -414,4 +390,4 @@ export function getPublishedNodesSchema(
   }
 
   return schema;
-}
+};

--- a/test/publishednodes-schema-generator-tests.ts
+++ b/test/publishednodes-schema-generator-tests.ts
@@ -141,7 +141,7 @@ describe('An example publishednodes.json file', () => {
     //console.log(validationErrors);
 
     expect(result).to.be.false;
-    expect(validationErrors).to.have.length(5);
+    expect(validationErrors).to.have.length(2);
     // check that require security is why it failed
     // by checking against the value of UseSecurity
     expect(
@@ -161,8 +161,9 @@ describe('When running against the generated publishednodes-schema.json an incor
     // modify the NodeId in the first element of the
     // publishedNodes.json file to trigger a parse
     // failure.
-    publishedNodes[0]['OpcNodes'][0]['Id'] = 'i=12345f';
-    const [result, validationErrors] = validateFile(publishedNodes, schema);
+    let pn = JSON.parse(JSON.stringify(publishedNodes));
+    pn[0]['OpcNodes'][0]['Id'] = 'i=12345f';
+    const [result, validationErrors] = validateFile(pn, schema);
     //console.log(validationErrors);
 
     expect(result).to.be.false;
@@ -176,7 +177,37 @@ describe('When running against the generated publishednodes-schema.json an incor
       (validationErrors as DefinedError[]).find(
         err =>
           err.schemaPath ===
-          '#/items/oneOf/0/properties/OpcNodes/items/0/properties/Id/pattern'
+          '#/items/oneOf/0/then/properties/OpcNodes/items/0/properties/Id/pattern'
+      )
+    ).to.exist;
+    expect(
+      (validationErrors as DefinedError[]).find(
+        err => err.instancePath === '/0'
+      )
+    ).to.exist;
+  });
+
+  it('should return one error when being validated with an integer NodeId, as the second array element, that includes a string', () => {
+    // modify the NodeId in the first element of the
+    // publishedNodes.json file to trigger a parse
+    // failure.
+    let pn = JSON.parse(JSON.stringify(publishedNodes));
+    pn[0]['OpcNodes'][2]['Id'] = 'i=12345f';
+    const [result, validationErrors] = validateFile(pn, schema);
+    //console.log(validationErrors);
+
+    expect(result).to.be.false;
+    expect(validationErrors).to.not.be.empty;
+    expect(
+      (validationErrors as DefinedError[]).find(
+        err => err.instancePath === '/0/OpcNodes/2/Id'
+      )
+    ).to.exist;
+    expect(
+      (validationErrors as DefinedError[]).find(
+        err =>
+          err.schemaPath ===
+          '#/items/oneOf/0/then/properties/OpcNodes/items/2/properties/Id/pattern'
       )
     ).to.exist;
     expect(
@@ -190,8 +221,9 @@ describe('When running against the generated publishednodes-schema.json an incor
     // modify the NodeId in the first element of the
     // publishedNodes.json file to trigger a parse
     // failure.
-    publishedNodes[0]['OpcNodes'][0]['Id'] = 'g=12345f';
-    const [result, validationErrors] = validateFile(publishedNodes, schema);
+    let pn = JSON.parse(JSON.stringify(publishedNodes));
+    pn[0]['OpcNodes'][0]['Id'] = 'g=12345f';
+    const [result, validationErrors] = validateFile(pn, schema);
     //console.log(validationErrors);
 
     expect(result).to.be.false;
@@ -205,7 +237,7 @@ describe('When running against the generated publishednodes-schema.json an incor
       (validationErrors as DefinedError[]).find(
         err =>
           err.schemaPath ===
-          '#/items/oneOf/0/properties/OpcNodes/items/0/properties/Id/pattern'
+          '#/items/oneOf/0/then/properties/OpcNodes/items/0/properties/Id/pattern'
       )
     ).to.exist;
     expect(
@@ -219,8 +251,9 @@ describe('When running against the generated publishednodes-schema.json an incor
     // modify the NodeId in the first element of the
     // publishedNodes.json file to trigger a parse
     // failure.
-    publishedNodes[0]['OpcNodes'][0]['Id'] = 'b=12345';
-    const [result, validationErrors] = validateFile(publishedNodes, schema);
+    let pn = JSON.parse(JSON.stringify(publishedNodes));
+    pn[0]['OpcNodes'][0]['Id'] = 'b=12345';
+    const [result, validationErrors] = validateFile(pn, schema);
     //console.log(validationErrors);
 
     expect(result).to.be.false;
@@ -234,7 +267,7 @@ describe('When running against the generated publishednodes-schema.json an incor
       (validationErrors as DefinedError[]).find(
         err =>
           err.schemaPath ===
-          '#/items/oneOf/0/properties/OpcNodes/items/0/properties/Id/pattern'
+          '#/items/oneOf/0/then/properties/OpcNodes/items/0/properties/Id/pattern'
       )
     ).to.exist;
     expect(

--- a/test/publishednodes-schema-generator-tests.ts
+++ b/test/publishednodes-schema-generator-tests.ts
@@ -56,7 +56,7 @@ describe('An example publishednodes.json file', () => {
     ];
 
     const [result, validationErrors] = validateFile(mixedModeSchema, schema);
-    console.log(validationErrors);
+    //console.log(validationErrors);
 
     expect(result).to.be.true;
     expect(validationErrors).to.be.null;
@@ -124,31 +124,75 @@ describe('An example publishednodes.json file', () => {
     expect(validationErrors).to.be.null;
   });
 
-  it('should not return an error when being validated with requireUseSecurity set to true', () => {
+  it('should not return an error when being validated with requireUseSecurity set to true, and when the UseSecurity flag is false', () => {
     const requireSecuritySchema = getPublishedNodesSchema(
       [
         NodeIdFormat.ExpandedNodeId,
         NodeIdFormat.NamespaceIndex,
         NodeIdFormat.NodeId,
       ],
-      true,
+      // require that UseSecurity is a required field in the schema 
+      // but do not require a check that it's value is 'true' 
+      false,
       true
     );
+    // set the UseSecurity property to true of the config file
+    let pn = JSON.parse(JSON.stringify(publishedNodes));
+
     const [result, validationErrors] = validateFile(
-      publishedNodes,
+      pn,
       requireSecuritySchema
     );
     //console.log(validationErrors);
 
+    // as the publishednodes configuration we are using does not
+    // have UseSecurity set to true, but the field is present, we
+    // should expect successful validation. 
+    expect(result).to.be.true;
+    expect(validationErrors).to.be.null;
+  });
+
+  it('should return an error when being validated with requireUseSecurity set to true, and when the UseSecurity flag must be true as well', () => {
+    const requireSecuritySchema = getPublishedNodesSchema(
+      [
+        NodeIdFormat.ExpandedNodeId,
+        NodeIdFormat.NamespaceIndex,
+        NodeIdFormat.NodeId,
+      ],
+      // require that UseSecurity is set to true and that it is a 
+      // required field in the configuration file. 
+      true,
+      true
+    );
+    // set the UseSecurity property to true of the config file
+    let pn = JSON.parse(JSON.stringify(publishedNodes));
+
+    const [result, validationErrors] = validateFile(
+      pn,
+      requireSecuritySchema
+    );
+    //console.log(validationErrors);
+
+    // as the publishednodes configuration we are using does not
+    // have UseSecurity set to true, but the field is present, we
+    // should expect a validation failure only on the false value check. 
     expect(result).to.be.false;
-    expect(validationErrors).to.have.length(2);
+
+    // as UseSecurity is a required field for the first two array
+    // elements of the schema, all subschema checks will fail. Hence,
+    // we should expect 14 failures. 
+    expect(validationErrors).to.have.length(14);
+
     // check that require security is why it failed
-    // by checking against the value of UseSecurity
+    // by checking against the value of UseSecurity.
+    // the top two schema both have the option for 
+    // UseSecurity, so we would expect 2 failure counts
+    // for that constraint. 
     expect(
-      (validationErrors as DefinedError[]).find(
+      (validationErrors as DefinedError[]).filter(
         err => err.instancePath === '/0/UseSecurity'
       )
-    ).to.exist;
+    ).to.have.length(2);
   });
 });
 
@@ -177,17 +221,19 @@ describe('When running against the generated publishednodes-schema.json an incor
       (validationErrors as DefinedError[]).find(
         err =>
           err.schemaPath ===
-          '#/items/oneOf/0/then/properties/OpcNodes/items/0/properties/Id/pattern'
+          '#/items/oneOf/0/properties/OpcNodes/items/properties/Id/pattern'
       )
     ).to.exist;
+    // since we will not be matching 2 of the potential subschema we should 
+    // expect that there will be two root validation errors
     expect(
-      (validationErrors as DefinedError[]).find(
+      (validationErrors as DefinedError[]).filter(
         err => err.instancePath === '/0'
       )
-    ).to.exist;
+    ).to.have.length(2);
   });
 
-  it('should return one error when being validated with an integer NodeId, as the second array element, that includes a string', () => {
+  it('should return one error when being validated with an integer NodeId, as the third array element, that includes a string', () => {
     // modify the NodeId in the first element of the
     // publishedNodes.json file to trigger a parse
     // failure.
@@ -207,7 +253,43 @@ describe('When running against the generated publishednodes-schema.json an incor
       (validationErrors as DefinedError[]).find(
         err =>
           err.schemaPath ===
-          '#/items/oneOf/0/then/properties/OpcNodes/items/2/properties/Id/pattern'
+          '#/items/oneOf/0/properties/OpcNodes/items/properties/Id/pattern'
+      )
+    ).to.exist;
+    expect(
+      (validationErrors as DefinedError[]).find(
+        err => err.instancePath === '/0'
+      )
+    ).to.exist;
+  });
+
+  it('should return one error when being validated with an integer NodeId, as the third and fifth array elements, include strings', () => {
+    // modify the NodeId in the first element of the
+    // publishedNodes.json file to trigger a parse
+    // failure.
+    let pn = JSON.parse(JSON.stringify(publishedNodes));
+    pn[0]['OpcNodes'][2]['Id'] = 'i=12345f';
+    pn[0]['OpcNodes'][4]['Id'] = 'i=12345g';
+    const [result, validationErrors] = validateFile(pn, schema);
+    //console.log(validationErrors);
+
+    expect(result).to.be.false;
+    expect(validationErrors).to.not.be.empty;
+    expect(
+      (validationErrors as DefinedError[]).find(
+        err => err.instancePath === '/0/OpcNodes/2/Id'
+      )
+    ).to.exist;
+    expect(
+      (validationErrors as DefinedError[]).find(
+        err => err.instancePath === '/0/OpcNodes/4/Id'
+      )
+    ).to.exist;
+    expect(
+      (validationErrors as DefinedError[]).find(
+        err =>
+          err.schemaPath ===
+          '#/items/oneOf/0/properties/OpcNodes/items/properties/Id/pattern'
       )
     ).to.exist;
     expect(
@@ -237,14 +319,16 @@ describe('When running against the generated publishednodes-schema.json an incor
       (validationErrors as DefinedError[]).find(
         err =>
           err.schemaPath ===
-          '#/items/oneOf/0/then/properties/OpcNodes/items/0/properties/Id/pattern'
+          '#/items/oneOf/0/properties/OpcNodes/items/properties/Id/pattern'
       )
     ).to.exist;
+    // since we will not be matching 2 of the potential subschema we should 
+    // expect that there will be two root validation errors
     expect(
-      (validationErrors as DefinedError[]).find(
+      (validationErrors as DefinedError[]).filter(
         err => err.instancePath === '/0'
       )
-    ).to.exist;
+    ).to.have.length(2);
   });
 
   it('should return one error when being validated with a ByteString NodeId that is not a ByteString', () => {
@@ -267,14 +351,16 @@ describe('When running against the generated publishednodes-schema.json an incor
       (validationErrors as DefinedError[]).find(
         err =>
           err.schemaPath ===
-          '#/items/oneOf/0/then/properties/OpcNodes/items/0/properties/Id/pattern'
+          '#/items/oneOf/0/properties/OpcNodes/items/properties/Id/pattern'
       )
     ).to.exist;
+    // since we will not be matching 2 of the potential subschema we should 
+    // expect that there will be two root validation errors
     expect(
-      (validationErrors as DefinedError[]).find(
+      (validationErrors as DefinedError[]).filter(
         err => err.instancePath === '/0'
       )
-    ).to.exist;
+    ).to.have.length(2);
   });
 });
 


### PR DESCRIPTION
This corrects an issue with how OCP Nodes within each subschema were being parsed. Only the first element of each array was validated and this fixes that, per stackoverflow issue: https://stackoverflow.com/questions/67309019/json-schema-validation-for-array-that-can-have-items-with-different-keys